### PR TITLE
Revert "Bump mlst version"

### DIFF
--- a/.github/data/expected_sequence_types.csv
+++ b/.github/data/expected_sequence_types.csv
@@ -1,4 +1,4 @@
 sample_id,scheme,sequence_type
-NC-000913.3,ecoli_achtman_4,10
-NC-016845.1,klebsiella,11
+NC-000913.3,ecoli,10
+NC-016845.1,kpneumoniae,11
 NZ-LR890181.1,cfreundii,8

--- a/.github/scripts/prepare_artifacts.sh
+++ b/.github/scripts/prepare_artifacts.sh
@@ -4,9 +4,9 @@ artifacts_dir="artifacts"
 
 echo "Prepare artifacts .." >> ${artifacts_dir}/test.log
 
-mkdir -p ${artifacts_dir}/assemblies
+mkdir -p ${artifacts_dir}/fastq
 
-cp -r .github/data/assemblies/* ${artifacts_dir}/assemblies
+mv .github/data/fastq/*.fastq.gz ${artifacts_dir}/fastq
 
 mkdir -p ${artifacts_dir}/pipeline_outputs
 

--- a/bin/parse_alleles.py
+++ b/bin/parse_alleles.py
@@ -14,7 +14,7 @@ def main(args):
         if args.sample_id:
             sample_id = args.sample_id
         else:
-            sample_id = sample['id']
+            sample_id = sample
 
         print(','.join([
             'sample_id',
@@ -26,11 +26,11 @@ def main(args):
             'score',
         ]))
 
-        if not sample['alleles']:
+        if not mlst[sample]['alleles']:
             continue
-        num_alleles = len(sample['alleles'])
-        scheme = sample['scheme']
-        for locus, allele in sample['alleles'].items():
+        num_alleles = len(mlst[sample]['alleles'])
+        scheme = mlst[sample]['scheme']
+        for locus, allele in mlst[sample]['alleles'].items():
             perfect_match = True
             novel_allele = False
             score = round(90 / num_alleles, 2)

--- a/environments/environment.yml
+++ b/environments/environment.yml
@@ -1,9 +1,9 @@
-name: mlst-nf
+name: mlst
 channels:
   - conda-forge
   - bioconda
   - defaults
 dependencies:
   - python=3
-  - mlst=2.23.0
+  - mlst=2.16.1
   - quast=5.0.2


### PR DESCRIPTION
Reverts BCCDC-PHL/mlst-nf#23

I'd like to tag a version so we can update our provenance file format, but not quite ready to adopt the updated mlst schemes/db. There are some changes to scheme names that we'll need to plan out how to incorporate into our overall analysis.